### PR TITLE
add 3.0 support for grimzy/laravel-mysql-spatial.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1.0",
-        "grimzy/laravel-mysql-spatial": "^2.1"
+        "grimzy/laravel-mysql-spatial": "^2.1 || ^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Honesty, I haven't checked changes version v2 to v3 for grimzy/laravel-mysql-spatial. But not possible to use davidpiesse/nova-map:0.0.5 with grimzy/laravel-mysql-spatial:v3 now.

https://github.com/grimzy/laravel-mysql-spatial/compare/2.2.3...3.0.0

```shell script
Using version ^0.0.5 for davidpiesse/nova-map
./composer.json has been updated
Loading composer repositories with package information                                                                                                                           Updating dependencies (including require-dev)         
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for davidpiesse/nova-map ^0.0.5 -> satisfiable by davidpiesse/nova-map[0.0.5].
    - davidpiesse/nova-map 0.0.5 requires grimzy/laravel-mysql-spatial ^2.1 -> satisfiable by grimzy/laravel-mysql-spatial[2.1.0, 2.1.1, 2.1.2, 2.1.3, 2.2.0, 2.2.1, 2.2.2, 2.2.3] but these conflict with your requirements or minimum-stability.


Installation failed, reverting ./composer.json to its original content.
```

I have tested when I add version v3.0, it seems okay and works well in my project.