### PR TITLE
Remove unused grimzy/laravel-mysql-spatial dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=7.1.0",
-        "grimzy/laravel-mysql-spatial": "^2.1 || ^3.0 || ^4.0 || ^5.0"
+        "php": ">=7.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Map.php
+++ b/src/Map.php
@@ -93,15 +93,4 @@ class Map extends Field
             break;
         }
     }
-
-    // protected function fillAttributeFromRequest(NovaRequest $request,
-    //                                             $requestAttribute,
-    //                                             $model,
-    //                                             $attribute)
-    // {
-    //     if ($request->exists($requestAttribute)) {
-    //         $geometry = Geometry::fromJson($request[$requestAttribute]);
-    //         $model->{$attribute} = $geometry;
-    //     }
-    // }
 }


### PR DESCRIPTION
Removed grimzy/laravel-mysql-spatial dependency as it is not used. It was only referenced in a function that was commented out in src/Map.php, which this PR also removes.

As discussed here: https://github.com/davidpiesse/nova-map/issues/40